### PR TITLE
Indent bibliography in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ for Discretized Data" to be published in the SIAM Journal of Scientific
 Computing". The publication details are below and in the Papers.bib file in bibtex
 format. 
 
-   Robey,R.N., Nicholaeff,D., and Robey,R.W. "Hash-Based Algorithms for Discretized Data", 
-   SIAM Journal of Scientific Computing, July 2013, Volume 35, Number 4, C346--C368
+    Robey,R.N., Nicholaeff,D., and Robey,R.W. "Hash-Based Algorithms for Discretized Data", 
+    SIAM Journal of Scientific Computing, July 2013, Volume 35, Number 4, C346--C368


### PR DESCRIPTION
Feel free to reject this change. It's simply a suggestion to further indent the bibliography so the markdown engine will put it in a mono-spaced block.
